### PR TITLE
Update requirements.txt

### DIFF
--- a/jupyterhub/requirements.txt
+++ b/jupyterhub/requirements.txt
@@ -3,3 +3,4 @@ openshift==0.6.1
 mod_wsgi==4.6.4
 Flask==1.0.2
 wrapt==1.10.11
+typing


### PR DESCRIPTION
My deployments fave been failing because typing is missing

Traceback (most recent call last):
File "/opt/app-root/bin/jupyterhub", line 3, in 
from jupyterhub.app import main
File "/opt/app-root/lib/python3.5/site-packages/jupyterhub/app.py", line 32, in 
from tornado.httpclient import AsyncHTTPClient
File "/opt/app-root/lib/python3.5/site-packages/tornado/httpclient.py", line 46, in 
from tornado.concurrent import (
File "/opt/app-root/lib/python3.5/site-packages/tornado/concurrent.py", line 34, in 
from tornado.log import app_log
File "/opt/app-root/lib/python3.5/site-packages/tornado/log.py", line 34, in 
from tornado.escape import _unicode
File "/opt/app-root/lib/python3.5/site-packages/tornado/escape.py", line 27, in 
from tornado.util import unicode_type
File "/opt/app-root/lib/python3.5/site-packages/tornado/util.py", line 21, in 
from typing import (
ImportError: cannot import name 'Type'